### PR TITLE
added simple error reporting

### DIFF
--- a/src/ILexer.java
+++ b/src/ILexer.java
@@ -1,5 +1,12 @@
 public interface ILexer {
     static int EOF = -1;
+    static int ILLEGAL_CHAR = 9;
+     Position position = null;
+     ErrorReporter errorReporter = new ErrorReporter();
     int  getToken();
     String getTokenName(int t);
+    private Position getPosition(){
+        return position;
+    }
+    void error(String t);
 }

--- a/src/Lexer.java
+++ b/src/Lexer.java
@@ -34,8 +34,8 @@ public class Lexer implements ILexer, Opcode {
         return this.ch = reader.read();
     }
 
-    private void error(String t) {
-        errorReporter.record( _Error.create(t, getPosition()) );
+     public void error(String t) {
+        errorReporter.record(_Error.create(t, getPosition()));
     }
 
     private void scanNumber() {

--- a/src/Parser.java
+++ b/src/Parser.java
@@ -46,6 +46,9 @@ public class Parser implements IParser {
         LineStmtSeq seq = new LineStmtSeq();
 
         while ( token != lexer.EOF ) {
+            if (token == lexer.ILLEGAL_CHAR){
+                lexer.error("Error reported");
+            }
             seq.add( parseLineStmt() );
         }
         return new TranslationUnit(seq);

--- a/src/SyntaxError.java
+++ b/src/SyntaxError.java
@@ -1,4 +1,4 @@
-public class SyntaxError extends Exception{
+public class SyntaxError extends Exception implements IReportable{
     private String msg;
     private Throwable cause;
     public SyntaxError(){
@@ -19,5 +19,11 @@ public class SyntaxError extends Exception{
     }
     public void setMessage(String msg){
         this.msg = msg;
+    }
+
+    @Override
+    public void record(_Error e) {
+        // TODO Auto-generated method stub
+
     }
 }


### PR DESCRIPTION
This is a shaky error reporting method.
It is not possible to implement the error reporting in the Instruction class as the error method is defined in the Lexer class.
The teacher defined the error(String t) method as private, this complicates things and might suggest the teacher wanted us to handle errors in the Lexer class. 
This temporary fix will allow us to handle errors while parsing; in which errors will not be added to sequence.
