### PR TITLE
Added error handling methods:

### DIFF
--- a/src/edu/soen341/projectb/assembler/ILexer.java
+++ b/src/edu/soen341/projectb/assembler/ILexer.java
@@ -10,7 +10,7 @@ public interface ILexer {
     static int EOF = -1;
     static int EOL = '\n';
     Tokens getToken() throws IOException;
-    String getTokenName(int t);
+    String getTokenName(Tokens t);
     Queue getTable();
     ISymbolTable getOpCodes();
     //boolean spellError(String line);

--- a/src/edu/soen341/projectb/assembler/Lexer.java
+++ b/src/edu/soen341/projectb/assembler/Lexer.java
@@ -5,6 +5,7 @@ import edu.soen341.projectb.helper.Position;
 import edu.soen341.projectb.nodes.ISymbolTable;
 import edu.soen341.projectb.nodes.SymbolTable;
 import edu.soen341.projectb.reportable.IReportable;
+import edu.soen341.projectb.reportable._Error;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -83,7 +84,7 @@ public class Lexer implements ILexer, Opcode {
 
 	private void error(String t) {
 
-		//errorReporter.record(_Error.create(t, getPosition()));
+		errorReporter.record(_Error.create(t, getPosition()));
 	}
 
 	private Tokens scanNumber() throws IOException {
@@ -228,7 +229,7 @@ public class Lexer implements ILexer, Opcode {
 				return scanString();
 
 			default:
-				read(); return Tokens.ILLEGAL_CHAR;
+				read(); error("Illegal char"); return Tokens.ILLEGAL_CHAR;
 			}
 		}
 		return Tokens.EOF;
@@ -236,8 +237,8 @@ public class Lexer implements ILexer, Opcode {
 	}
 
 	@Override
-	public String getTokenName(int t) {
-		return null;
+	public String getTokenName(Tokens t) {
+		return t.name();
 	}
 
 

--- a/src/edu/soen341/projectb/assembler/Parser.java
+++ b/src/edu/soen341/projectb/assembler/Parser.java
@@ -34,10 +34,10 @@ public class Parser implements IParser {
 
 
     // Record the error: <t> expected, found <token> at <token>.position
-    /*
-    protected void expect(int t) throws IOException {
+    
+    protected void expect(Tokens t) throws IOException {
         if (t != token) {
-            String expected = "INHERENT IDENTIFIER";
+            String expected = lexer.getTokenName(t);
             errorReporter.record( _Error.create( expected+" expected", lexer.getPosition()));
             errorReporter.getException();
             System.out.println(expected);
@@ -45,7 +45,7 @@ public class Parser implements IParser {
         }
     }
 
-     */
+     
     /*protected void expect(String t) {
         errorReporter.record( _Error.create(t+" expected", lexer.getPosition()) );
     }

--- a/src/edu/soen341/projectb/assembler/Tokens.java
+++ b/src/edu/soen341/projectb/assembler/Tokens.java
@@ -15,3 +15,4 @@ public enum Tokens{
     STRING,
  };
 
+


### PR DESCRIPTION
For Lexer: If getToken returns ILLEGAL CHAR, Lexer will called the error method which uses errorReporter to record an error in _Error.
For Parser: Added expect(Token t) method, I believe the best implementation to use this method would be to add the expect in the parse, so
if the parser expects a label and finds something else, the method would record the error.